### PR TITLE
jj - created database table for diningcommonsmenuitems

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem
+ * 
+ * A UCSBDiningCommonsMenuItem is a dining commons menu item at UCSB
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSBDiningCommonsMenuItem entities
+ */
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems-1",
+          "author": "JayJ",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #8 
In this PR, we created a database table for UCSBDiningCommonsMenuItems, with an autogenerated Long as its id field, and the following fields:

```
String diningCommonsCode
String name
String station
```

You can test this by running on localhost and looking for the UCSBDiningCommonsMenuItems table on H2 Console

<img width="281" alt="image" src="https://github.com/user-attachments/assets/aabbff3d-3c97-4c42-ac67-9ec676bde6c3" />

You can also test this by running on dokku and connecting to the postgres database, and running \dt:

```
jayjoo@dokku-12:~$ dokku postgres:connect team01-dev-tizerk-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_tizerk_db=# \dt
                   List of relations
 Schema |            Name            | Type  |  Owner   
--------+----------------------------+-------+----------
 public | databasechangelog          | table | postgres
 public | databasechangeloglock      | table | postgres
 public | restaurants                | table | postgres
 public | ucsbdates                  | table | postgres
 public | ucsbdiningcommons          | table | postgres
 public | ucsbdiningcommonsmenuitems | table | postgres
 public | users                      | table | postgres
(7 rows)

team01_dev_tizerk_db=# 
```
My dokku deployment: https://team01-dev-tizerk.dokku-12.cs.ucsb.edu/