### PR TITLE
Jj ucsb dining commons menu item put endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
@@ -78,4 +78,19 @@ public class UCSBDiningCommonsMenuItemsController extends ApiController {
 
         return savedUcsbDiningCommonsMenuItem;
     }
+
+    /**
+     * Get a single record from the table; 
+     * use the value passed in as a @RequestParam to do a lookup by id. 
+     * If a matching row is found, return the row as a JSON object, 
+     * otherwise throw an EntityNotFoundException.
+     * @return a UCSBDiningCommonsMenuitem JSON object
+     */
+    @Operation(summary= "List a particular ucsb dining commons menu item by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getUCSBDiningCommonsMenuItem(@Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+        return item;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
@@ -93,4 +93,30 @@ public class UCSBDiningCommonsMenuItemsController extends ApiController {
         UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
         return item;
     }
+
+    /**
+     * Update a single menu item
+     * 
+     * @param id       id of the menu item to update
+     * @param incoming the new menu item
+     * @return the updated menu item object
+     */
+    @Operation(summary= "Update a single menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+        @Parameter(name="id") @RequestParam Long id,
+        @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        ucsbDiningCommonsMenuItem.setName(incoming.getName());
+        ucsbDiningCommonsMenuItem.setStation(incoming.getStation());
+
+        ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return ucsbDiningCommonsMenuItem;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTests.java
@@ -3,9 +3,11 @@ package edu.ucsb.cs156.example.controllers;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -72,6 +74,56 @@ public class UCSBDiningCommonsMenuItemsControllerTests extends ControllerTestCas
         String expectedJson = mapper.writeValueAsString(expectedDiningCommonsMenuItems);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for for GET by id
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+            .name("firstDiningCommonsMenuItem")
+            .diningCommonsCode("firstDiningCommonsCode")
+            .station("firstStation")
+            .build();
+
+            when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
     }
 
     // Authorization tests for /api/ucsbdiningcommonsmenuitems/post


### PR DESCRIPTION
Closes #11 
In this PR, we created a PUT endpoint for updating one item from the diningcommonsmenuitems table using an JSON object with the id of a pre-existing menu item.
You can test this on localhost or dokku with Swagger.
<img width="729" alt="image" src="https://github.com/user-attachments/assets/c01f1fcb-30f3-4f36-ad02-50dae7119f48" />
My dokku deployment: https://team01-dev-tizerk.dokku-12.cs.ucsb.edu/