### PR TITLE
aw - Added GET endpoint for single record in Articles table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -5,8 +5,11 @@ import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -83,5 +88,22 @@ import lombok.extern.slf4j.Slf4j;
  
          return savedArticles;
      }
+
+     /**
+      * Get a single article by id
+      * 
+      * @param id the id of the articles
+      * @return a Articles
+      */
+      @Operation(summary= "Get a single article")
+      @PreAuthorize("hasRole('ROLE_USER')")
+      @GetMapping("")
+      public Articles getById(
+              @Parameter(name="id") @RequestParam Long id) {
+          Articles articles = articlesRepository.findById(id)
+                  .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+  
+          return articles;
+      }
  }
  

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.Articles;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Closes #40 

This PS adds the GET a single record for Articles table by ID.

This can be tested on localhost and dokku by running either and through Swagger, use the GET a single article operation by inputting an ID. If the ID exists, the article details will be shown. Otherwise, an error will be thrown.
<img width="455" alt="image" src="https://github.com/user-attachments/assets/547ab655-c240-4b77-83b1-f1c75985618a" />

Dokku deployed at: https://team01-dev-arthurwu17.dokku-12.cs.ucsb.edu/