### PR TITLE
mw - Add GET endpoint for single record in HelpRequests table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -49,23 +49,6 @@ public class HelpRequestController extends ApiController {
     }
 
     /**
-     * Get a single help request by id
-     * 
-     * @param id the id of the help request
-     * @return a HelpRequest
-     */
-    @Operation(summary= "Get a single help request")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("")
-    public HelpRequest getById(
-            @Parameter(name="id") @RequestParam Long id) {
-        HelpRequest helpRequest = helpRequestRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
-
-        return helpRequest;
-    }
-
-    /**
      * Create a new help request
      * 
      * @param requesterEmail      the requester's email
@@ -106,4 +89,20 @@ public class HelpRequestController extends ApiController {
         return savedHelpRequest;
     }
 
+    /**
+     * Get a single help request by id
+     * 
+     * @param id the id of the help request
+     * @return a HelpRequest
+     */
+    @Operation(summary= "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,6 +46,23 @@ public class HelpRequestController extends ApiController {
     public Iterable<HelpRequest> allHelpRequests() {
         Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
         return helpRequests;
+    }
+
+    /**
+     * Get a single help request by id
+     * 
+     * @param id the id of the help request
+     * @return a HelpRequest
+     */
+    @Operation(summary= "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
     }
 
     /**


### PR DESCRIPTION
Closes #34 

[Dokku deployment](https://team01-dev-mic-wu.dokku-12.cs.ucsb.edu/)

This PR adds an endpoint to `HelpRequestsController` that allows us to `GET` a single help request by id.

<img width="537" alt="image" src="https://github.com/user-attachments/assets/f45cb0b6-f1f3-47d7-8096-67f9bc15f24b" />
