### PR TITLE
aw articles controller put

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -105,5 +104,33 @@ import lombok.extern.slf4j.Slf4j;
   
           return articles;
       }
+
+     /**
+      * Update a single article
+      * 
+      * @param id       id of the article to update
+      * @param incoming the new article
+      * @return the updated article object
+      */
+     @Operation(summary= "Update a single article")
+     @PreAuthorize("hasRole('ROLE_ADMIN')")
+     @PutMapping("")
+     public Articles updateArticles(
+             @Parameter(name="id") @RequestParam Long id,
+             @RequestBody @Valid Articles incoming) {
+ 
+         Articles articles = articlesRepository.findById(id)
+                 .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+ 
+         articles.setTitle(incoming.getTitle());
+         articles.setUrl(incoming.getUrl());
+         articles.setExplanation(incoming.getExplanation());
+         articles.setEmail(incoming.getEmail());
+         articles.setDateAdded(incoming.getDateAdded());
+ 
+         articlesRepository.save(articles);
+ 
+         return articles;
+     }
  }
  


### PR DESCRIPTION
Closes #41

This PR adds the operation PUT for the Articles database. The PUT operation allows admin users to edit an Article.
You can test this on both localhost and dokku by running either, and accessing the operation through Swagger in the Articles database.
<img width="753" alt="image" src="https://github.com/user-attachments/assets/f1353645-01d1-487c-a153-5a5f4f1c99ee" />

Dokku deployed: https://team01-dev-arthurwu17.dokku-12.cs.ucsb.edu/