### PR TITLE
hk - implemented deletion for recommendation request table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -107,4 +107,32 @@ public class RecommendationRequestController extends ApiController {
         return recReq;
     }
 
+        /**
+     * Update a single recommendation request
+     * 
+     * @param id       id of the recommendation request to update
+     * @param incoming the new recommendation request
+     * @return the updated recommendation request object
+     */
+    @Operation(summary= "Update a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public RecommendationRequest updateRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid RecommendationRequest incoming) {
+
+        RecommendationRequest request = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        request.setRequesterEmail(incoming.getRequesterEmail());
+        request.setExplanation(incoming.getExplanation());
+        request.setDateRequested(incoming.getDateRequested());
+        request.setDateNeeded(incoming.getDateNeeded());
+        request.setDone(incoming.getDone());
+        request.setProfessorEmail(incoming.getProfessorEmail());
+
+        recommendationRequestRepository.save(request);
+        
+        return request;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,94 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+/**
+ * This is a REST controller for Recommendation Request
+ */
+
+@Tag(name = "RecommendationRequest")
+@RequestMapping("/api/recommendationrequest")
+@RestController
+@Slf4j
+
+public class RecommendationRequestController extends ApiController {
+    @Autowired
+    RecommendationRequestRepository recommendationRequestRepository;
+    
+    /**
+     * List all Recommendation Requests
+     * 
+     * @return an iterable of RecommendationRequest
+     */
+    @Operation(summary= "List all recommendation requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RecommendationRequest> allRecommendationRequests() {
+        Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+        return requests;
+    }
+
+    /**
+     * Create a new Recommendation Request
+     *
+     * @param explanation
+     * @param dateNeeded
+     * @param requesterEmail
+     * @param done
+     * @param dateRequested
+     * @param professorEmail
+     * @return the created RecommendationRequest
+     */
+    @Operation(summary = "Create a new recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+
+    public RecommendationRequest postRecommendationRequest(
+            @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name = "explanation") @RequestParam String explanation,
+            @Parameter(name = "dateRequested", description = "date (in ISO format, e.g. YYYY-MM-DDTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateRequested") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateRequested,
+            @Parameter(name = "dateNeeded", description = "date (in ISO format, e.g. YYYY-MM-DDTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateNeeded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateNeeded,
+            @Parameter(name = "done") @RequestParam boolean done,
+            @Parameter(name = "professorEmail") @RequestParam String professorEmail)
+            throws JsonProcessingException {
+
+        log.info("Creating recommendation request: requester={}, professor={}, requestedDate={}, neededDate={}, doneStatus={}",
+                requesterEmail, professorEmail, dateRequested, dateNeeded, done);
+
+        RecommendationRequest rRequest = new RecommendationRequest();
+        rRequest.setRequesterEmail(requesterEmail);
+        rRequest.setExplanation(explanation);
+        rRequest.setDateRequested(dateRequested);
+        rRequest.setDateNeeded(dateNeeded);
+        rRequest.setDone(done);
+        rRequest.setProfessorEmail(professorEmail);
+
+        RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(rRequest);
+        return savedRecommendationRequest;
+}
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -135,4 +135,23 @@ public class RecommendationRequestController extends ApiController {
         
         return request;
     }
+
+    /**
+     * Delete a recommendation request
+     * 
+     * @param id the id of the recommendation request to delete
+     * @return a message indicating the recommendation request was deleted
+     */
+    @Operation(summary = "Delete a recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id) {
+
+        RecommendationRequest toDelete = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(toDelete);
+
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -90,5 +90,21 @@ public class RecommendationRequestController extends ApiController {
         RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(rRequest);
         return savedRecommendationRequest;
 }
+    /**
+     * Get a single recommendation request
+     * 
+     * @param id the id of the recommendation request
+     * @return a RecommendationRequest
+     */
+    @Operation(summary= "Get a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RecommendationRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recReq = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        return recReq;
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a Recommendation Request
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendation_requests")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+  
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "recommendation_requests")
+@Entity(name = "recommendationrequest")
 public class RecommendationRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDate entities.
+ */
+
+@Repository
+public interface RecommendationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
+}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequests-1",
+          "author": "hungkhuu04",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATIONREQUEST"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATIONREQUEST_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATIONREQUEST"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -215,4 +215,94 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
         }
 
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
+        // arrange
+        LocalDateTime dateReq1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        LocalDateTime dateNeeded1 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+        RecommendationRequest RecommendationRequest1 = RecommendationRequest.builder()
+                .requesterEmail("student1@ucsb.edu")
+                .explanation("test1")
+                .dateRequested(dateReq1)
+                .dateNeeded(dateNeeded1)
+                .done(false)
+                .professorEmail("prof1@ucsb.edu")
+                .build();
+
+        LocalDateTime dateReq2 = LocalDateTime.parse("2022-01-04T00:00:00");
+        LocalDateTime dateNeeded2 = LocalDateTime.parse("2023-01-04T00:00:00");
+
+        RecommendationRequest RecommendationRequest2 = RecommendationRequest.builder()
+                .requesterEmail("student2@ucsb.edu")
+                .explanation("updated explanation")
+                .dateRequested(dateReq2)
+                .dateNeeded(dateNeeded2)
+                .done(true)
+                .professorEmail("prof2@ucsb.edu")
+                .build();
+
+        String requestBody = mapper.writeValueAsString(RecommendationRequest2);
+
+        when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(RecommendationRequest1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/recommendationrequest?id=67")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(recommendationRequestRepository, times(1)).findById(67L);
+        verify(recommendationRequestRepository, times(1)).save(RecommendationRequest2);
+
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_recommendationrequest_that_does_not_exist() throws Exception {
+        // arrange
+        LocalDateTime dateRequested = LocalDateTime.parse("2022-01-01T00:00:00");
+        LocalDateTime dateNeeded = LocalDateTime.parse("2022-02-01T00:00:00");
+
+        RecommendationRequest editRequest = RecommendationRequest.builder()
+                .requesterEmail("student1@ucsb.edu")
+                .professorEmail("prof1@ucsb.edu")
+                .explanation("edit")
+                .dateRequested(dateRequested)
+                .dateNeeded(dateNeeded)
+                .done(true)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(editRequest);
+
+        when(recommendationRequestRepository.findById(eq(999L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/recommendationrequest?id=999")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        // assert
+        verify(recommendationRequestRepository, times(1)).findById(999L);
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("RecommendationRequest with id 999 not found", json.get("message"));
+        }
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,161 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+    @MockBean
+    RecommendationRequestRepository recommendationRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/recommendationrequest/admin/all
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/recommendationrequest/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/recommendationrequest/all"))
+                            .andExpect(status().is(200)); // logged
+    }       
+
+    // Authorization tests for /api/recommendationrequest/post
+    // (Perhaps should also have these for put and delete)
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/recommendationrequest/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/recommendationrequest/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_recommendation_requests() throws Exception {
+
+            // arrange
+            LocalDateTime dateReq1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime dateNeeded1 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+            RecommendationRequest RecommendationRequest1 = RecommendationRequest.builder()
+                            .requesterEmail("student1@ucsb.edu")
+                            .explanation("test1")
+                            .dateRequested(dateReq1)
+                            .dateNeeded(dateNeeded1)
+                            .done(false)
+                            .professorEmail("prof1@ucsb.edu")
+                            .build();
+
+            LocalDateTime dateReq2 = LocalDateTime.parse("2022-01-04T00:00:00");
+            LocalDateTime dateNeeded2 = LocalDateTime.parse("2023-01-04T00:00:00");
+
+            RecommendationRequest RecommendationRequest2 = RecommendationRequest.builder()
+                            .requesterEmail("student2@ucsb.edu")
+                            .explanation("test1")
+                            .dateRequested(dateReq2)
+                            .dateNeeded(dateNeeded2)
+                            .done(false)
+                            .professorEmail("prof2@ucsb.edu")
+                            .build();
+
+            ArrayList<RecommendationRequest> expectedDates = new ArrayList<>();
+            expectedDates.addAll(Arrays.asList(RecommendationRequest1, RecommendationRequest2));
+
+            when(recommendationRequestRepository.findAll()).thenReturn(expectedDates);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/recommendationrequest/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(recommendationRequestRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedDates);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+            
+    @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
+                // arrange
+
+            LocalDateTime dateReq1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime dateNeeded1 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+            RecommendationRequest RecommendationRequest1 = RecommendationRequest.builder()
+                            .requesterEmail("student1@ucsb.edu")
+                            .explanation("test1")
+                            .dateRequested(dateReq1)
+                            .dateNeeded(dateNeeded1)
+                            .done(false)
+                            .professorEmail("prof1@ucsb.edu")
+                            .build();
+
+            when(recommendationRequestRepository.save(eq(RecommendationRequest1))).thenReturn(RecommendationRequest1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/recommendationrequest/post")
+                                    .param("requesterEmail", "student1@ucsb.edu")
+                                    .param("professorEmail", "prof1@ucsb.edu")
+                                    .param("explanation", "test1")
+                                    .param("dateRequested", "2022-01-03T00:00:00")
+                                    .param("dateNeeded", "2023-01-03T00:00:00")
+                                    .param("done", "false")
+                                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // assert
+            verify(recommendationRequestRepository, times(1)).save(RecommendationRequest1);
+            String expectedJson = mapper.writeValueAsString(RecommendationRequest1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+
+}


### PR DESCRIPTION
Closes #24 
In this PR we allow admin to delete recommendation requests that were already posted. (100% mutation coverage and 100% jacoco report)



<img width="1163" alt="Screenshot 2025-04-26 at 5 23 04 AM" src="https://github.com/user-attachments/assets/dbcf6c67-318d-4517-9714-362bc4c5bb75" />
